### PR TITLE
Make things build on Haiku

### DIFF
--- a/cpclib-bndbuild/src/env.rs
+++ b/cpclib-bndbuild/src/env.rs
@@ -23,7 +23,7 @@ pub fn create_template_env<P: AsRef<Utf8Path>, S1: AsRef<str>, S2: AsRef<str>>(
         }
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "haiku"))]
     fn basm_escape_path(path: String) -> Result<String, Error> {
         Ok(path)
     }

--- a/cpclib-crunchers/build.rs
+++ b/cpclib-crunchers/build.rs
@@ -41,7 +41,7 @@ fn build_others() {
 fn build_shrinkler() {
     cxx_build::bridge("src/shrinkler.rs")
         .file("extra/Shrinkler4.6NoParityContext//basm_bridge.cpp")
-        .flag_if_supported("-std=c++14")
+        .std("c++14")
         .compile("cpclib-crunchers");
 
     println!("cargo:rerun-if-changed=src/shrinkler.rs");

--- a/cpclib-runner/src/delegated.rs
+++ b/cpclib-runner/src/delegated.rs
@@ -62,7 +62,8 @@ pub fn github_get_assets_for_version_url<GI: GithubInformation>(
 pub struct MutiplatformUrls {
     pub linux: Option<String>,
     pub windows: Option<String>,
-    pub macos: Option<String>
+    pub macos: Option<String>,
+    pub haiku: Option<String>
 }
 
 impl MutiplatformUrls {
@@ -71,6 +72,7 @@ impl MutiplatformUrls {
             .linux(url)
             .windows(url)
             .macos(url)
+            .haiku(url)
             .build()
     }
 
@@ -81,6 +83,8 @@ impl MutiplatformUrls {
         return self.macos.as_ref();
         #[cfg(target_os = "linux")]
         return self.linux.as_ref();
+        #[cfg(target_os = "haiku")]
+        return self.haiku.as_ref();
     }
 }
 

--- a/cpclib-runner/src/runner/assembler/rasm.rs
+++ b/cpclib-runner/src/runner/assembler/rasm.rs
@@ -70,7 +70,7 @@ impl ExecutableInformation for RasmVersion {
         return "rasm_w64.exe";
         #[cfg(target_os = "macos")]
         return "rasm.macOS";
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "haiku"))]
         return "rasm";
     }
 }
@@ -92,7 +92,7 @@ impl CompilableInformation for RasmVersion {
 
 impl DownloadableInformation for RasmVersion {
     fn target_os_archive_format(&self) -> ArchiveFormat {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "haiku"))]
         return ArchiveFormat::Zip;
         #[cfg(target_os = "windows")]
         return ArchiveFormat::Raw;

--- a/cpclib-runner/src/runner/assembler/sjasmplus.rs
+++ b/cpclib-runner/src/runner/assembler/sjasmplus.rs
@@ -55,7 +55,7 @@ impl ExecutableInformation for SjasmplusVersion {
     }
 
     fn target_os_exec_fname(&self) -> &'static str {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "haiku"))]
         return "sjasmplus";
         #[cfg(target_os = "windows")]
         return "sjasmplus.exe";
@@ -83,7 +83,7 @@ impl CompilableInformation for SjasmplusVersion {
 
 impl DownloadableInformation for SjasmplusVersion {
     fn target_os_archive_format(&self) -> ArchiveFormat {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "haiku"))]
         return ArchiveFormat::TarXz;
         #[cfg(target_os = "windows")]
         return ArchiveFormat::Zip;

--- a/cpclib-runner/src/runner/assembler/vasm.rs
+++ b/cpclib-runner/src/runner/assembler/vasm.rs
@@ -21,7 +21,7 @@ impl DownloadableInformation for VasmVersion {
             VasmVersion::V2021_03_19 => {
                 #[cfg(target_os = "windows")]
                 return ArchiveFormat::Zip;
-                #[cfg(target_os = "macos")]
+                #[cfg(any(target_os = "macos", target_os = "haiku"))]
                 todo!("VASM archive format not defined for macOS");
                 #[cfg(target_os = "linux")]
                 return ArchiveFormat::Tar; // XXX yep extension is wrong
@@ -39,7 +39,8 @@ impl StaticInformation for VasmVersion {
                     MutiplatformUrls {
                         linux: Some("http://www.ibaug.de/vbcc/vbcc_linux_x64.tar.gz".to_owned()),
                         windows: Some("http://www.ibaug.de/vbcc/vbcc_win_x64.zip".to_owned()),
-                        macos: None
+                        macos: None,
+                        haiku: None,
                     }
                 })
             }
@@ -59,7 +60,7 @@ impl ExecutableInformation for VasmVersion {
         return "bin/vasmz80_oldstyle.exe";
         #[cfg(target_os = "macos")]
         todo!("VASM executable not defined for macOS");
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "haiku"))]
         return "vbcc/bin/vasmz80_oldstyle";
     }
 }

--- a/cpclib-runner/src/runner/ay/minimiser.rs
+++ b/cpclib-runner/src/runner/ay/minimiser.rs
@@ -17,9 +17,7 @@ impl MinimiserVersion {
     }
 }
 
-cfg_select! {
-    target_os = "windows" =>
-    {
+#[cfg(target_os = "windows")]
         impl MinimiserVersion {
             pub fn configuration<E: EventObserver>(&self) -> DelegateApplicationDescription<E> {
                 match self {
@@ -33,10 +31,8 @@ cfg_select! {
                 }
             }
         }
-    }
 
-    target_os = "linux" =>
-    {
+#[cfg(target_os = "linux")]
         impl MinimiserVersion {
             pub fn configuration<E: EventObserver>(&self) -> DelegateApplicationDescription<E> {
                 match self {
@@ -50,14 +46,10 @@ cfg_select! {
                 }
             }
         }
-    }
 
-     target_os = "macos" =>
-    {
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
         impl MinimiserVersion {
             pub fn configuration<E: EventObserver>(&self) -> DelegateApplicationDescription<E> {
                 unimplemented!()
             }
         }
-    }
-}

--- a/cpclib-runner/src/runner/emulator/ace.rs
+++ b/cpclib-runner/src/runner/emulator/ace.rs
@@ -29,6 +29,8 @@ impl DownloadableInformation for AceVersion {
         return ArchiveFormat::Zip;
         #[cfg(target_os = "linux")]
         return ArchiveFormat::TarGz;
+        #[cfg(target_os = "haiku")]
+        return ArchiveFormat::Zip;
         #[cfg(target_os = "macos")]
         return ArchiveFormat::Zip;
     }
@@ -66,28 +68,32 @@ impl DynamicUrlInformation for AceVersion {
                 Ok(MutiplatformUrls {
                     linux,
                     windows,
-                    macos
+                    macos,
+                    haiku: None
                 })
             },
             AceVersion::Bnd4 => {
                 Ok(MutiplatformUrls {
                     linux: Some("https://roudoudou.com/ACE-DL/BZen.tar.gz".to_string()),
                     windows: Some("https://roudoudou.com/ACE-DL/W64bnd4.zip".to_string()),
-                    macos: None
+                    macos: None,
+                    haiku: None
                 })
             },
             AceVersion::ZenSummer => {
                 Ok(MutiplatformUrls {
                     linux: Some("https://roudoudou.com/ACE-DL/LinuxZenSummer.tar.gz".to_string()),
                     windows: Some("https://roudoudou.com/ACE-DL/Win64Summer.zip".to_string()),
-                    macos: None
+                    macos: None,
+                    haiku: None
                 })
             },
             AceVersion::WakePoint => {
                 Ok(MutiplatformUrls {
                     linux: Some("https://roudoudou.com/ACE-DL/BZen.tar.gz".to_string()),
                     windows: Some("https://roudoudou.com/ACE-DL/BWIN64.zip".to_string()),
-                    macos: Some("https://roudoudou.com/ACE-DL/BMAC.zip".to_string())
+                    macos: Some("https://roudoudou.com/ACE-DL/BMAC.zip".to_string()),
+                    haiku: None
                 })
             },
         }
@@ -109,6 +115,8 @@ impl ExecutableInformation for AceVersion {
         return "AceDL.exe";
         #[cfg(target_os = "linux")]
         return "AceDL";
+        #[cfg(target_os = "haiku")]
+        return "ACE";
         #[cfg(target_os = "macos")]
         return "AceDL.app/Contents/MacOS/AceDL";
     }

--- a/cpclib-runner/src/runner/emulator/caprice_forever.rs
+++ b/cpclib-runner/src/runner/emulator/caprice_forever.rs
@@ -30,7 +30,7 @@ impl ExecutableInformation for CapriceForeverVersion {
                 return "Caprice64.exe";
                 #[cfg(target_os = "linux")]
                 return "Caprice64.exe";
-                #[cfg(target_os = "macos")]
+                #[cfg(any(target_os = "macos", target_os = "haiku"))]
                 todo!("Caprice Forever not available on macOS");
             }
         }

--- a/cpclib-runner/src/runner/emulator/cpcemupower.rs
+++ b/cpclib-runner/src/runner/emulator/cpcemupower.rs
@@ -35,6 +35,8 @@ impl ExecutableInformation for CpcEmuPowerVersion {
                 return "CPCEPower_SDL_Linux_x64";
                 #[cfg(target_os = "macos")]
                 return "CPCEPower_SDL_MacOS";
+                #[cfg(target_os = "haiku")]
+                return "CPCEPower_SDL_Haiku";
             }
         }
     }

--- a/cpclib-runner/src/runner/emulator/sugarbox.rs
+++ b/cpclib-runner/src/runner/emulator/sugarbox.rs
@@ -30,7 +30,7 @@ impl DownloadableInformation for SugarBoxV2Version {
     fn target_os_archive_format(&self) -> ArchiveFormat {
         #[cfg(target_os = "windows")]
         return ArchiveFormat::SevenZ;
-        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "haiku"))]
         return ArchiveFormat::TarGz;
     }
 }
@@ -45,6 +45,8 @@ impl ExecutableInformation for SugarBoxV2Version {
                 return "Sugarbox-2.0.3-Darwin";
                 #[cfg(target_os = "linux")]
                 return "Sugarbox-2.0.3-Linux";
+                #[cfg(target_os = "haiku")]
+                return "Sugarbox-2.0.3-Haiku";
             },
             SugarBoxV2Version::V2_0_2 => {
                 #[cfg(target_os = "windows")]
@@ -53,6 +55,8 @@ impl ExecutableInformation for SugarBoxV2Version {
                 return "Sugarbox-2.0.2-Darwin";
                 #[cfg(target_os = "linux")]
                 return "Sugarbox-2.0.2-Linux";
+                #[cfg(target_os = "haiku")]
+                return "Sugarbox-2.0.2-Haiku";
             }
         }
     }
@@ -62,6 +66,8 @@ impl ExecutableInformation for SugarBoxV2Version {
         return "Sugarbox.exe";
         #[cfg(target_os = "macos")]
         return "Sugarbox";
+        #[cfg(target_os = "haiku")]
+        return "sugarbox";
         #[cfg(target_os = "linux")]
         return match self {
             Self::V2_0_3 => "Sugarbox-2.0.3-Linux/Sugarbox",

--- a/cpclib-runner/src/runner/grafx2.rs
+++ b/cpclib-runner/src/runner/grafx2.rs
@@ -26,6 +26,8 @@ impl Grafx2Version {
             Self::V2_9 => DOWNLOAD_URL_V2_P_APPIMAGE,
             #[cfg(target_os = "macos")]
             Self::V2_9 => DOWNLOAD_URL_V2_9_MACOS,
+            #[cfg(target_os = "haiku")]
+            Self::V2_9 => "cmd:grafx2",
             #[allow(unreachable_patterns)]
             _ => unreachable!()
         };
@@ -40,6 +42,8 @@ impl Grafx2Version {
         let exec = "GrafX2-2.9.3245-x86_64.AppImage";
         #[cfg(target_os = "macos")]
         let exec = "GrafX2";
+        #[cfg(target_os = "haiku")]
+        let exec = "grafx2";
 
         #[cfg(target_os = "windows")]
         let archive_format = ArchiveFormat::Zip;
@@ -47,6 +51,8 @@ impl Grafx2Version {
         let archive_format = ArchiveFormat::Raw;
         #[cfg(target_os = "macos")]
         let archive_format = ArchiveFormat::Zip;
+        #[cfg(target_os = "haiku")]
+        let archive_format = ArchiveFormat::Raw;
 
         let builder = DelegateApplicationDescription::builder()
             .download_fn_url(url) // we assume a modern CPU

--- a/cpclib-runner/src/runner/hspcompiler.rs
+++ b/cpclib-runner/src/runner/hspcompiler.rs
@@ -62,7 +62,7 @@ impl ExecutableInformation for HspCompilerVersion {
         return "compiler.exe";
         #[cfg(target_os = "macos")]
         todo!("HSPCompiler executable not defined for macOS");
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "haiku"))]
         return "hspcompiler";
     }
 }
@@ -80,7 +80,7 @@ impl CompilableInformation for HspCompilerVersion {
 
 impl DownloadableInformation for HspCompilerVersion {
     fn target_os_archive_format(&self) -> ArchiveFormat {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "haiku"))]
         return ArchiveFormat::Zip;
         #[cfg(target_os = "windows")]
         return ArchiveFormat::Raw;

--- a/cpclib-runner/src/runner/impdisc.rs
+++ b/cpclib-runner/src/runner/impdisc.rs
@@ -18,9 +18,7 @@ impl ImpDskVersion {
     }
 }
 
-cfg_select! {
-    target_os = "linux" =>
-    {
+#[cfg(any(target_os = "linux", target_os = "haiku"))]
         impl ImpDskVersion {
             pub fn configuration<E: EventObserver>(&self) -> DelegateApplicationDescription<E> {
                 match self {
@@ -31,9 +29,8 @@ cfg_select! {
                                     }
             }
         }
-    }
-    target_os = "windows" =>
-    {
+
+#[cfg(target_os = "windows")]
         impl ImpDskVersion {
             pub fn configuration<E: EventObserver>(&self) -> DelegateApplicationDescription<E> {
                 match self {
@@ -76,9 +73,7 @@ cfg_select! {
             }
         }
 
-    }
-    target_os = "macos" =>
-    {
+#[cfg(target_os = "macos")]
         impl ImpDskVersion {
             pub fn configuration<E: EventObserver>(&self) -> DelegateApplicationDescription<E> {
                 match self {
@@ -125,7 +120,3 @@ cfg_select! {
                 }
             }
         }
-    }
-    _ => {
-    }
-}

--- a/cpclib-runner/src/runner/martine.rs
+++ b/cpclib-runner/src/runner/martine.rs
@@ -16,9 +16,7 @@ impl MartineVersion {
     }
 }
 
-cfg_select! {
-    target_os = "linux" =>
-    {
+#[cfg(any(target_os = "linux", target_os = "haiku"))]
         impl MartineVersion {
             pub fn configuration<E: EventObserver>(&self) -> DelegateApplicationDescription<E> {
                 match self {
@@ -39,9 +37,8 @@ cfg_select! {
                 }
             }
         }
-    }
-    target_os = "windows" =>
-    {
+
+#[cfg(target_os = "windows")]
         impl MartineVersion {
             pub fn configuration<E: EventObserver>(&self) -> DelegateApplicationDescription<E> {
                 match self {
@@ -63,9 +60,7 @@ cfg_select! {
             }
         }
 
-    }
-    target_os = "macos" =>
-    {
+#[cfg(target_os = "macos")]
         impl MartineVersion {
             pub fn configuration<E: EventObserver>(&self) -> DelegateApplicationDescription<E> {
                 match self {
@@ -140,7 +135,3 @@ exec "$MARTINE_EXEC" "$@"
                 }
             }
         }
-    }
-    _ => {
-    }
-}


### PR DESCRIPTION
- Remove use of cfg_select (not available yet in Rust 1.94.1)
- Define some URLs and archive types for Haiku (just so things can be built, the URLs may not exist or be for the wrong platform)